### PR TITLE
feat(deps): includes all "bumps" dep exp in commits

### DIFF
--- a/pkg/cmd/generate/templates.go
+++ b/pkg/cmd/generate/templates.go
@@ -17,9 +17,9 @@ type ChangeGroup struct {
 func PullRequestWithLabels(prs []github.PullRequest, labels ...string) []github.PullRequest {
 	prsWithLabel := make([]github.PullRequest, 0)
 	for i := range prs {
-		pr := &prs[i]
+		pr := prs[i]
 		if Contains(pr.Labels, labels...) {
-			prsWithLabel = append(prsWithLabel, *pr)
+			prsWithLabel = append(prsWithLabel, pr)
 		}
 	}
 	return prsWithLabel

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -36,6 +36,7 @@ type AssociatedPRsQuery struct {
 						Nodes []struct {
 							Oid             string
 							MessageHeadline string
+							Message         string
 							AuthoredDate    githubv4.DateTime
 							Author          struct {
 								User struct {
@@ -107,6 +108,7 @@ func FindAssociatedPRs(client *githubv4.Client, repo []string, matchingCommit Ma
 						Author:          node.Author.User.Login,
 						MessageHeadline: node.MessageHeadline,
 						CreatedAt:       node.AuthoredDate,
+						Message:         node.Message,
 					},
 					Title:     pr.Title,
 					Number:    pr.Number,

--- a/pkg/github/types.go
+++ b/pkg/github/types.go
@@ -15,6 +15,7 @@ type PullRequest struct {
 type Commit struct {
 	Hash            string
 	MessageHeadline string
+	Message         string
 	Author          string
 	CreatedAt       githubv4.DateTime
 }


### PR DESCRIPTION
#### Short description of what this resolves:

Scan commit message for "bumps" version dependency expressions
anywhere. This allow "bumps" in regular feature commits to be
included in the deps updated section.

#### Changes proposed in this pull request:

Scan each line in all commit messages and clone the PR object if one
found and append to the deps PR list. PRs do not have to include a
"dependencies" label to be included in the scan. If it does contain
a "dependencies" label it will be excluded from the "others" PR list
and not show up as a "feature".

Includes a new way of getting the "to" version to avoid miss typed expressions etc etc. It will now scan the Line in reverse and get the first found "version looking segment" (`[0-9]+\.[0-9]`)
